### PR TITLE
[TJ-43013] adding field to specify mime_type in transaction_document upload

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$/../.." vcs="Git" />
-  </component>
+    <component name="VcsDirectoryMappings">
+        <mapping directory="$PROJECT_DIR$/../.." vcs="Git" />
+    </component>
 </project>

--- a/v6/schemas.go
+++ b/v6/schemas.go
@@ -1160,15 +1160,16 @@ func (m TransactionDocumentTrashesResponse) IsRef() bool {
 
 type TransactionDocumentUpload struct {
 	FolderId string `json:"folder_id,omitempty"`
+	MimeType string `json:"mime_type,omitempty"`
 	Title    string `json:"title,omitempty"`
 }
 
-type TransactionDocumentUploadResponseResult struct {
+type TransactionDocumentUploadResult struct {
 	TransactionDocuments []*TransactionDocument `json:"transaction_documents,omitempty"`
 	Object               string                 `json:"object,omitempty"`
 }
 
-func (m TransactionDocumentUploadResponseResult) IsRef() bool {
+func (m TransactionDocumentUploadResult) IsRef() bool {
 	return strings.HasPrefix(m.Object, "/ref/")
 }
 
@@ -1263,9 +1264,9 @@ func (m UpdateTransactionMetaResponse) IsRef() bool {
 }
 
 type UploadsResponse struct {
-	Result        *TransactionDocumentUploadResponseResult `json:"result,omitempty"`
-	TransactionId string                                   `json:"transaction_id,omitempty"`
-	Object        string                                   `json:"object,omitempty"`
+	Result        *TransactionDocumentUploadResult `json:"result,omitempty"`
+	TransactionId string                           `json:"transaction_id,omitempty"`
+	Object        string                           `json:"object,omitempty"`
 }
 
 func (m UploadsResponse) IsRef() bool {


### PR DESCRIPTION
Adding a new field to receive the mime_type of the files that are trying to be uploaded. This change is to support the capability to support different file types