### PR TITLE
Support GET endpoints for transaction signature requests

### DIFF
--- a/v6/schemas.go
+++ b/v6/schemas.go
@@ -898,9 +898,13 @@ type SignatureDetectionSchema struct {
 
 type SignatureRequest struct {
 	Id               string                       `json:"id,omitempty"`
+	CompletedAt      int                          `json:"completed_at,omitempty"`
+	CreatedAt        int                          `json:"created_at,omitempty"`
 	Documents        []*SignatureRequestDocument  `json:"documents,omitempty"`
 	EnvelopeId       string                       `json:"envelope_id,omitempty"`
 	FlowId           string                       `json:"flow_id,omitempty"`
+	IsArchived       *bool                        `json:"is_archived,omitempty"`
+	Provider         string                       `json:"provider,omitempty"`
 	Recipients       []*SignatureRequestRecipient `json:"recipients,omitempty"`
 	RevisionFlowId   string                       `json:"revision_flow_id,omitempty"`
 	SentAt           int                          `json:"sent_at,omitempty"`
@@ -914,6 +918,29 @@ type SignatureRequest struct {
 
 func (m SignatureRequest) IsRef() bool {
 	return strings.HasPrefix(m.Object, "/ref/")
+}
+
+type SignatureRequestList struct {
+	Data       []SignatureRequest `json:"data"`
+	ListObject string             `json:"list_object"`
+	Object     string             `json:"object"`
+	HasMore    bool               `json:"has_more"`
+}
+
+func (m SignatureRequestList) IsRef() bool {
+	return strings.HasPrefix(m.Object, "/ref/")
+}
+
+func (m SignatureRequestList) NextPageParams() core.PageParams {
+	if !m.HasMore {
+		return nil
+	}
+
+	pageSize := len(m.Data)
+	return &core.PageParamsImpl{
+		StartingAfter: m.Data[pageSize-1].Id,
+		Limit:         pageSize,
+	}
 }
 
 type SignatureRequestDocument struct {
@@ -942,17 +969,8 @@ func (m SignatureRequestFlowResponse) IsRef() bool {
 	return strings.HasPrefix(m.Object, "/ref/")
 }
 
-type SignatureRequestList struct {
-	PageNumber        int                 `json:"page_number,omitempty"`
-	SignatureRequests []*SignatureRequest `json:"signature_requests,omitempty"`
-	Object            string              `json:"object,omitempty"`
-}
-
-func (m SignatureRequestList) IsRef() bool {
-	return strings.HasPrefix(m.Object, "/ref/")
-}
-
 type SignatureRequestRecipient struct {
+	Id            string `json:"id,omitempty"`
 	Email         string `json:"email,omitempty"`
 	Order         int    `json:"order,omitempty"`
 	RecipientRole string `json:"recipient_role,omitempty"`
@@ -1016,26 +1034,27 @@ func (m TaskList) NextPageParams() core.PageParams {
 }
 
 type Transaction struct {
-	Id                    string                   `json:"id,omitempty"`
-	Address               *Address                 `json:"address,omitempty"`
-	Archived              *bool                    `json:"archived,omitempty"`
-	DealId                string                   `json:"deal_id,omitempty"`
-	Fields                TransactionFields        `json:"fields,omitempty"`
-	Folders               *FolderList              `json:"folders,omitempty"`
-	IngestDocumentsEmail  string                   `json:"ingest_documents_email,omitempty"`
-	IsLease               *bool                    `json:"is_lease,omitempty"`
-	IsReferral            *bool                    `json:"is_referral,omitempty"`
-	Parties               *PartyList               `json:"parties,omitempty"`
-	PropertiesInfo        *PropertyInfoList        `json:"properties_info,omitempty"`
-	ReState               string                   `json:"re_state,omitempty"`
-	SecondaryAddressesIds []string                 `json:"secondary_addresses_ids,omitempty"`
-	Side                  string                   `json:"side,omitempty"`
-	Stage                 string                   `json:"stage,omitempty"`
-	Tasks                 *TaskList                `json:"tasks,omitempty"`
-	Title                 string                   `json:"title,omitempty"`
-	TransactionDocuments  *TransactionDocumentList `json:"transaction_documents,omitempty"`
-	TransactionPackages   *TransactionPackageList  `json:"transaction_packages,omitempty"`
-	Object                string                   `json:"object,omitempty"`
+	Id                           string                   `json:"id,omitempty"`
+	Address                      *Address                 `json:"address,omitempty"`
+	Archived                     *bool                    `json:"archived,omitempty"`
+	DealId                       string                   `json:"deal_id,omitempty"`
+	Fields                       TransactionFields        `json:"fields,omitempty"`
+	Folders                      *FolderList              `json:"folders,omitempty"`
+	IngestDocumentsEmail         string                   `json:"ingest_documents_email,omitempty"`
+	IsLease                      *bool                    `json:"is_lease,omitempty"`
+	IsReferral                   *bool                    `json:"is_referral,omitempty"`
+	Parties                      *PartyList               `json:"parties,omitempty"`
+	PropertiesInfo               *PropertyInfoList        `json:"properties_info,omitempty"`
+	ReState                      string                   `json:"re_state,omitempty"`
+	SecondaryAddressesIds        []string                 `json:"secondary_addresses_ids,omitempty"`
+	Side                         string                   `json:"side,omitempty"`
+	Stage                        string                   `json:"stage,omitempty"`
+	Tasks                        *TaskList                `json:"tasks,omitempty"`
+	Title                        string                   `json:"title,omitempty"`
+	TransactionDocuments         *TransactionDocumentList `json:"transaction_documents,omitempty"`
+	TransactionPackages          *TransactionPackageList  `json:"transaction_packages,omitempty"`
+	TransactionSignatureRequests *SignatureRequestList    `json:"transaction_signature_requests,omitempty"`
+	Object                       string                   `json:"object,omitempty"`
 }
 
 func (m Transaction) IsRef() bool {

--- a/v6/transaction_signature_requests.go
+++ b/v6/transaction_signature_requests.go
@@ -1,0 +1,47 @@
+package glide
+
+import (
+	"fmt"
+
+	"github.com/retitle/go-sdk/v6/core"
+)
+
+type TransactionSignatureRequestsResource interface {
+	GetDetail(transactionId string, id string, opts ...core.RequestOption) (*SignatureRequest, error)
+	GetMulti(transactionId string, ids []string, opts ...core.RequestOption) (*SignatureRequestList, error)
+	List(transactionId string, opts ...core.RequestOption) (*SignatureRequestList, error)
+}
+
+type transactionSignatureRequestsResourceImpl struct {
+	client Client
+}
+
+func GetTransactionSignatureRequestsResource(client Client) TransactionSignatureRequestsResource {
+	return transactionSignatureRequestsResourceImpl{
+		client: client,
+	}
+}
+
+func (r transactionSignatureRequestsResourceImpl) GetDetail(transactionId string, id string, opts ...core.RequestOption) (*SignatureRequest, error) {
+	res := SignatureRequest{}
+	if err := r.client.Get(&res, true, fmt.Sprintf("/transactions/%s/transaction_signature_requests/%s", transactionId, id), opts...); err != nil {
+		return nil, err
+	}
+	return &res, nil
+}
+
+func (r transactionSignatureRequestsResourceImpl) GetMulti(transactionId string, ids []string, opts ...core.RequestOption) (*SignatureRequestList, error) {
+	res := SignatureRequestList{}
+	if err := r.client.Get(&res, true, fmt.Sprintf("/transactions/%s/transaction_signature_requests", transactionId), append(opts, core.WithReqOptQueryParamList("ids", ids))...); err != nil {
+		return nil, err
+	}
+	return &res, nil
+}
+
+func (r transactionSignatureRequestsResourceImpl) List(transactionId string, opts ...core.RequestOption) (*SignatureRequestList, error) {
+	res := SignatureRequestList{}
+	if err := r.client.Get(&res, true, fmt.Sprintf("/transactions/%s/transaction_signature_requests", transactionId), opts...); err != nil {
+		return nil, err
+	}
+	return &res, nil
+}

--- a/v6/transactions.go
+++ b/v6/transactions.go
@@ -13,6 +13,7 @@ type TransactionsResource interface {
 	Tasks() TasksResource
 	TransactionDocuments() TransactionDocumentsResource
 	TransactionPackages() TransactionPackagesResource
+	TransactionSignatureRequests() TransactionSignatureRequestsResource
 	GetDetail(id string, opts ...core.RequestOption) (*Transaction, error)
 	GetMulti(ids []string, opts ...core.RequestOption) (*TransactionList, error)
 	List(opts ...core.RequestOption) (*TransactionList, error)
@@ -42,24 +43,26 @@ type TransactionsResource interface {
 }
 
 type transactionsResourceImpl struct {
-	client               Client
-	folders              FoldersResource
-	parties              PartiesResource
-	propertiesInfo       PropertiesInfoResource
-	tasks                TasksResource
-	transactionDocuments TransactionDocumentsResource
-	transactionPackages  TransactionPackagesResource
+	client                       Client
+	folders                      FoldersResource
+	parties                      PartiesResource
+	propertiesInfo               PropertiesInfoResource
+	tasks                        TasksResource
+	transactionDocuments         TransactionDocumentsResource
+	transactionPackages          TransactionPackagesResource
+	transactionSignatureRequests TransactionSignatureRequestsResource
 }
 
 func GetTransactionsResource(client Client) TransactionsResource {
 	return transactionsResourceImpl{
-		client:               client,
-		folders:              GetFoldersResource(client),
-		parties:              GetPartiesResource(client),
-		propertiesInfo:       GetPropertiesInfoResource(client),
-		tasks:                GetTasksResource(client),
-		transactionDocuments: GetTransactionDocumentsResource(client),
-		transactionPackages:  GetTransactionPackagesResource(client),
+		client:                       client,
+		folders:                      GetFoldersResource(client),
+		parties:                      GetPartiesResource(client),
+		propertiesInfo:               GetPropertiesInfoResource(client),
+		tasks:                        GetTasksResource(client),
+		transactionDocuments:         GetTransactionDocumentsResource(client),
+		transactionPackages:          GetTransactionPackagesResource(client),
+		transactionSignatureRequests: GetTransactionSignatureRequestsResource(client),
 	}
 }
 
@@ -85,6 +88,10 @@ func (r transactionsResourceImpl) TransactionDocuments() TransactionDocumentsRes
 
 func (r transactionsResourceImpl) TransactionPackages() TransactionPackagesResource {
 	return r.transactionPackages
+}
+
+func (r transactionsResourceImpl) TransactionSignatureRequests() TransactionSignatureRequestsResource {
+	return r.transactionSignatureRequests
 }
 
 func (r transactionsResourceImpl) GetDetail(id string, opts ...core.RequestOption) (*Transaction, error) {


### PR DESCRIPTION
Add `TransactionSignatureRequests` resource, supporting GET endpoints `/transactions/<tid>/transaction_signature_requests` and  `/transactions/<tid>/transaction_signature_requests/<sr_id>`