### PR TITLE
Add one more data field to GetEsignFlowDocuments API response

### DIFF
--- a/v6/schemas.go
+++ b/v6/schemas.go
@@ -569,6 +569,7 @@ type GetSignatureRequestFlowDocumentsResponse struct {
 	DestinationFolderId          string   `json:"destination_folder_id,omitempty"`
 	HideFieldMoveOriginalToTrash *bool    `json:"hide_field_move_original_to_trash,omitempty"`
 	LockedTransactionDocumentIds []string `json:"locked_transaction_document_ids,omitempty"`
+	MakeDocumentsVisibleInCd     *bool    `json:"make_documents_visible_in_cd,omitempty"`
 	MoveOriginalToTrash          *bool    `json:"move_original_to_trash,omitempty"`
 	TransactionDocumentIds       []string `json:"transaction_document_ids,omitempty"`
 	Object                       string   `json:"object,omitempty"`


### PR DESCRIPTION
### Descriptions 
- Follow this [PR comment](https://github.com/UrbanCompass/compass-glide-devapp/pull/2487#discussion_r2012644385), adding new field `make_documents_visible_in_cd` to the API response body. 

### Context 
- https://compass-tech.atlassian.net/browse/TJ-46083
- https://compass-tech.atlassian.net/browse/TJ-46084