### PR TITLE
renaming activities to envelope_activities

### DIFF
--- a/v6/envelope_activities.go
+++ b/v6/envelope_activities.go
@@ -1,0 +1,29 @@
+package glide
+
+import (
+	"fmt"
+
+	"github.com/retitle/go-sdk/v6/core"
+)
+
+type EnvelopeActivitiesResource interface {
+	GetDetail(id string, opts ...core.RequestOption) (*EnvelopeActivityListWithCursor, error)
+}
+
+type envelopeActivitiesResourceImpl struct {
+	client Client
+}
+
+func GetEnvelopeActivitiesResource(client Client) EnvelopeActivitiesResource {
+	return envelopeActivitiesResourceImpl{
+		client: client,
+	}
+}
+
+func (r envelopeActivitiesResourceImpl) GetDetail(id string, opts ...core.RequestOption) (*EnvelopeActivityListWithCursor, error) {
+	res := EnvelopeActivityListWithCursor{}
+	if err := r.client.Get(&res, true, fmt.Sprintf("/envelopes/%s/envelope_activities", id), opts...); err != nil {
+		return nil, err
+	}
+	return &res, nil
+}

--- a/v6/envelopes.go
+++ b/v6/envelopes.go
@@ -10,31 +10,31 @@ type EnvelopesResource interface {
 	EnvelopeDocument() EnvelopeDocumentResource
 	EnvelopeRecipient() EnvelopeRecipientResource
 	Step() StepResource
-	Activities() ActivitiesResource
+	EnvelopeActivities() EnvelopeActivitiesResource
 	GetDetail(id string, opts ...core.RequestOption) (*Envelope, error)
 	Create(envelopeCreateIntentSchema EnvelopeCreateIntentSchema, opts ...core.RequestOption) (*EnvelopeCreateResponse, error)
-	StartRevision(id string, opts ...core.RequestOption) (*EnvelopeStartRevisionResponse, error)
-	CancelRevision(id string, opts ...core.RequestOption) (*EnvelopeCancelRevisionResponse, error)
+	CancelRevision(id string, envelopeCancelRevisionSchema EnvelopeCancelRevisionSchema, opts ...core.RequestOption) (*EnvCancelReviseResponse, error)
 	Resend(id string, opts ...core.RequestOption) (*EnvelopeResendResponse, error)
+	Revise(id string, envelopeStartRevisionSchema EnvelopeStartRevisionSchema, opts ...core.RequestOption) (*EnvStartReviseResponse, error)
 	SendRevision(id string, envelopeSendRevisionSchema EnvelopeSendRevisionSchema, opts ...core.RequestOption) (*EnvSendRevisionResponse, error)
 	Void(id string, envelopeVoidSchema EnvelopeVoidSchema, opts ...core.RequestOption) (*EnvelopeVoidResponse, error)
 }
 
 type envelopesResourceImpl struct {
-	client            Client
-	envelopeDocument  EnvelopeDocumentResource
-	envelopeRecipient EnvelopeRecipientResource
-	step              StepResource
-	activities        ActivitiesResource
+	client             Client
+	envelopeDocument   EnvelopeDocumentResource
+	envelopeRecipient  EnvelopeRecipientResource
+	step               StepResource
+	envelopeActivities EnvelopeActivitiesResource
 }
 
 func GetEnvelopesResource(client Client) EnvelopesResource {
 	return envelopesResourceImpl{
-		client:            client,
-		envelopeDocument:  GetEnvelopeDocumentResource(client),
-		envelopeRecipient: GetEnvelopeRecipientResource(client),
-		step:              GetStepResource(client),
-		activities:        GetActivitiesResource(client),
+		client:             client,
+		envelopeDocument:   GetEnvelopeDocumentResource(client),
+		envelopeRecipient:  GetEnvelopeRecipientResource(client),
+		step:               GetStepResource(client),
+		envelopeActivities: GetEnvelopeActivitiesResource(client),
 	}
 }
 
@@ -50,8 +50,8 @@ func (r envelopesResourceImpl) Step() StepResource {
 	return r.step
 }
 
-func (r envelopesResourceImpl) Activities() ActivitiesResource {
-	return r.activities
+func (r envelopesResourceImpl) EnvelopeActivities() EnvelopeActivitiesResource {
+	return r.envelopeActivities
 }
 
 func (r envelopesResourceImpl) GetDetail(id string, opts ...core.RequestOption) (*Envelope, error) {
@@ -70,25 +70,9 @@ func (r envelopesResourceImpl) Create(envelopeCreateIntentSchema EnvelopeCreateI
 	return &res, nil
 }
 
-func (r envelopesResourceImpl) StartRevision(id string, opts ...core.RequestOption) (*EnvelopeStartRevisionResponse, error) {
-	res := EnvelopeStartRevisionResponse{}
-	if err := r.client.Post(&res, true, fmt.Sprintf("/envelopes/%s/revise", id), nil, opts...); err != nil {
-		return nil, err
-	}
-	return &res, nil
-}
-
-func (r envelopesResourceImpl) CancelRevision(id string, opts ...core.RequestOption) (*EnvelopeCancelRevisionResponse, error) {
-	res := EnvelopeCancelRevisionResponse{}
-	if err := r.client.Post(&res, true, fmt.Sprintf("/envelopes/%s/cancelRevision", id), nil, opts...); err != nil {
-		return nil, err
-	}
-	return &res, nil
-}
-
-func (r envelopesResourceImpl) SendRevision(id string, envelopeSendRevisionSchema EnvelopeSendRevisionSchema, opts ...core.RequestOption) (*EnvSendRevisionResponse, error) {
-	res := EnvSendRevisionResponse{}
-	if err := r.client.Post(&res, true, fmt.Sprintf("/envelopes/%s/send_revision", id), envelopeSendRevisionSchema, opts...); err != nil {
+func (r envelopesResourceImpl) CancelRevision(id string, envelopeCancelRevisionSchema EnvelopeCancelRevisionSchema, opts ...core.RequestOption) (*EnvCancelReviseResponse, error) {
+	res := EnvCancelReviseResponse{}
+	if err := r.client.Post(&res, true, fmt.Sprintf("/envelopes/%s/cancelRevision", id), envelopeCancelRevisionSchema, opts...); err != nil {
 		return nil, err
 	}
 	return &res, nil
@@ -97,6 +81,22 @@ func (r envelopesResourceImpl) SendRevision(id string, envelopeSendRevisionSchem
 func (r envelopesResourceImpl) Resend(id string, opts ...core.RequestOption) (*EnvelopeResendResponse, error) {
 	res := EnvelopeResendResponse{}
 	if err := r.client.Post(&res, true, fmt.Sprintf("/envelopes/%s/resend", id), nil, opts...); err != nil {
+		return nil, err
+	}
+	return &res, nil
+}
+
+func (r envelopesResourceImpl) Revise(id string, envelopeStartRevisionSchema EnvelopeStartRevisionSchema, opts ...core.RequestOption) (*EnvStartReviseResponse, error) {
+	res := EnvStartReviseResponse{}
+	if err := r.client.Post(&res, true, fmt.Sprintf("/envelopes/%s/revise", id), envelopeStartRevisionSchema, opts...); err != nil {
+		return nil, err
+	}
+	return &res, nil
+}
+
+func (r envelopesResourceImpl) SendRevision(id string, envelopeSendRevisionSchema EnvelopeSendRevisionSchema, opts ...core.RequestOption) (*EnvSendRevisionResponse, error) {
+	res := EnvSendRevisionResponse{}
+	if err := r.client.Post(&res, true, fmt.Sprintf("/envelopes/%s/send_revision", id), envelopeSendRevisionSchema, opts...); err != nil {
 		return nil, err
 	}
 	return &res, nil


### PR DESCRIPTION
Renaming activities to envelope activities.


This is necessary due to an existing limitation in the sdk, that won't work with multiple resources of the sane name