### PR TITLE
Make Selected Td Ids Param Not Required for Apply Templates Intent

### DIFF
--- a/v6/schemas.go
+++ b/v6/schemas.go
@@ -2501,11 +2501,11 @@ func (m TransactionPackageList) NextPageParams() core.PageParams {
 
 type TransactionSelectedTemplate struct {
 	TemplateId             string   `json:"template_id"`
-	TransactionDocumentIds []string `json:"transaction_document_ids"`
+	TransactionDocumentIds []string `json:"transaction_document_ids,omitempty"`
 }
 
 type TransactionSelectedTemplates struct {
-	SelectedTemplateDocuments []*TransactionSelectedTemplate `json:"selected_template_documents"`
+	SelectedTemplateDocuments []*TransactionSelectedTemplate `json:"selected_template_documents,omitempty"`
 	TemplateIds               []string                       `json:"template_ids"`
 }
 


### PR DESCRIPTION
Changes were made in this [PR](https://github.com/UrbanCompass/compass-glide-devapp/pull/5408) to modify the external API request schema for Apply Templates intent. The change was to make selected_template_documents and transaction_document_ids optional parameters - removing the validation error users were receiving whenever they are not passed in. By making them optional parameters, the fallback mechanism would get hit where it would apply all template documents into the transaction.

This PR copies and pastes the code changes in compass-glide-devapp to this repo