### PR TITLE
minor: Add Header Propagation interface/decorator

### DIFF
--- a/v6/core/context_header_http_client.go
+++ b/v6/core/context_header_http_client.go
@@ -1,0 +1,105 @@
+package core
+
+import "context"
+
+// HeaderExtractor is a function that derives HTTP headers to inject into outbound
+// Glide SDK requests from a context. Returning an empty or nil map is safe.
+//
+// Callers can provide multiple extractors; all results are merged before the
+// request is made. If two extractors return the same header name the last one
+// wins (consistent with the behaviour of WithHeader).
+//
+// Example — propagating a Compass trace ID:
+//
+//	func CompassHeaders(ctx context.Context) map[string]string {
+//	    if tid := traceid.FromContext(ctx); tid != "" {
+//	        return map[string]string{"X-Compass-Trace-Id": string(tid)}
+//	    }
+//	    return nil
+//	}
+type HeaderExtractor func(ctx context.Context) map[string]string
+
+type contextHeaderHttpClient struct {
+	ctx        context.Context
+	httpClient HttpClient
+	extractors []HeaderExtractor
+}
+
+var _ HttpClient = (*contextHeaderHttpClient)(nil)
+
+// NewContextHeaderHttpClient wraps httpClient so that every outbound request
+// automatically includes the headers returned by each extractor.
+//
+// ctx is captured at construction time and forwarded to each extractor on
+// every request. Like TracingHttpClientDecorator, a fresh instance must be
+// constructed for each request-context scope — do not share one instance
+// across requests with different contexts.
+//
+// The injected headers are prepended to the opts slice, so explicit
+// per-call WithHeader options and the Authorization header appended by
+// ClientImpl.request always take precedence.
+//
+// To add new propagated headers in the future, simply add another
+// HeaderExtractor (or extend an existing one) — no other code needs to change.
+func NewContextHeaderHttpClient(
+	ctx context.Context,
+	httpClient HttpClient,
+	extractors ...HeaderExtractor,
+) HttpClient {
+	return &contextHeaderHttpClient{
+		ctx:        ctx,
+		httpClient: httpClient,
+		extractors: extractors,
+	}
+}
+
+// headerOpts builds the RequestOption slice for the headers extracted from ctx.
+func (c *contextHeaderHttpClient) headerOpts() []RequestOption {
+	var opts []RequestOption
+	for _, extract := range c.extractors {
+		for name, value := range extract(c.ctx) {
+			if name != "" && value != "" {
+				opts = append(opts, WithHeader(name, value))
+			}
+		}
+	}
+	return opts
+}
+
+// prepend returns the extracted header options followed by the caller's opts,
+// so that any explicit caller-supplied header for the same name wins.
+func (c *contextHeaderHttpClient) prepend(opts []RequestOption) []RequestOption {
+	headerOpts := c.headerOpts()
+	if len(headerOpts) == 0 {
+		return opts
+	}
+	return append(headerOpts, opts...)
+}
+
+func (c *contextHeaderHttpClient) Get(res interface{}, url string, opts ...RequestOption) error {
+	return c.httpClient.Get(res, url, c.prepend(opts)...)
+}
+
+func (c *contextHeaderHttpClient) GetStream(res BinaryResponse, url string, opts ...RequestOption) error {
+	return c.httpClient.GetStream(res, url, c.prepend(opts)...)
+}
+
+func (c *contextHeaderHttpClient) Post(res interface{}, url string, payload interface{}, opts ...RequestOption) error {
+	return c.httpClient.Post(res, url, payload, c.prepend(opts)...)
+}
+
+func (c *contextHeaderHttpClient) PostWithFiles(res interface{}, url string, payload interface{}, files []File, opts ...RequestOption) error {
+	return c.httpClient.PostWithFiles(res, url, payload, files, c.prepend(opts)...)
+}
+
+func (c *contextHeaderHttpClient) Request(res interface{}, requestMethod string, url string, opts ...RequestOption) error {
+	return c.httpClient.Request(res, requestMethod, url, c.prepend(opts)...)
+}
+
+func (c *contextHeaderHttpClient) RequestBinary(res BinaryResponse, requestMethod string, url string, opts ...RequestOption) error {
+	return c.httpClient.RequestBinary(res, requestMethod, url, c.prepend(opts)...)
+}
+
+func (c *contextHeaderHttpClient) SetRequester(requester HttpClientRequester) {
+	c.httpClient.SetRequester(requester)
+}

--- a/v6/core/context_header_http_client_test.go
+++ b/v6/core/context_header_http_client_test.go
@@ -1,0 +1,191 @@
+package core
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// capturingHttpClient records the RequestOptions of every call so tests can
+// assert which headers were injected.
+type capturingHttpClient struct {
+	lastOpts RequestOptionsImpl
+}
+
+func (c *capturingHttpClient) capture(opts []RequestOption) {
+	c.lastOpts = RequestOptionsImpl{}
+	for _, opt := range opts {
+		opt(&c.lastOpts)
+	}
+}
+
+func (c *capturingHttpClient) Get(_ interface{}, _ string, opts ...RequestOption) error {
+	c.capture(opts)
+	return nil
+}
+func (c *capturingHttpClient) GetStream(_ BinaryResponse, _ string, opts ...RequestOption) error {
+	c.capture(opts)
+	return nil
+}
+func (c *capturingHttpClient) Post(_ interface{}, _ string, _ interface{}, opts ...RequestOption) error {
+	c.capture(opts)
+	return nil
+}
+func (c *capturingHttpClient) PostWithFiles(_ interface{}, _ string, _ interface{}, _ []File, opts ...RequestOption) error {
+	c.capture(opts)
+	return nil
+}
+func (c *capturingHttpClient) Request(_ interface{}, _ string, _ string, opts ...RequestOption) error {
+	c.capture(opts)
+	return nil
+}
+func (c *capturingHttpClient) RequestBinary(_ BinaryResponse, _ string, _ string, opts ...RequestOption) error {
+	c.capture(opts)
+	return nil
+}
+func (c *capturingHttpClient) SetRequester(_ HttpClientRequester) {}
+
+// traceExtractor is a simple HeaderExtractor that returns a fixed trace ID header.
+func traceExtractor(traceID string) HeaderExtractor {
+	return func(_ context.Context) map[string]string {
+		if traceID == "" {
+			return nil
+		}
+		return map[string]string{"X-Compass-Trace-Id": traceID}
+	}
+}
+
+func TestContextHeaderHttpClient_InjectsHeadersOnAllMethods(t *testing.T) {
+	const traceID = "crafting-test-trace-abc123"
+
+	methods := []struct {
+		name string
+		act  func(client HttpClient)
+	}{
+		{"Get", func(c HttpClient) { _ = c.Get(nil, "http://example.com") }},
+		{"GetStream", func(c HttpClient) { _ = c.GetStream(nil, "http://example.com") }},
+		{"Post", func(c HttpClient) { _ = c.Post(nil, "http://example.com", nil) }},
+		{"PostWithFiles", func(c HttpClient) { _ = c.PostWithFiles(nil, "http://example.com", nil, nil) }},
+		{"Request", func(c HttpClient) { _ = c.Request(nil, "PUT", "http://example.com") }},
+		{"RequestBinary", func(c HttpClient) { _ = c.RequestBinary(nil, "GET", "http://example.com") }},
+	}
+
+	for _, tt := range methods {
+		t.Run(tt.name, func(t *testing.T) {
+			inner := &capturingHttpClient{}
+			client := NewContextHeaderHttpClient(context.Background(), inner, traceExtractor(traceID))
+
+			tt.act(client)
+
+			assert.Equal(t, http.Header{"X-Compass-Trace-Id": []string{traceID}}, inner.lastOpts.GetHeaders())
+		})
+	}
+}
+
+func TestContextHeaderHttpClient_NoHeadersWhenExtractorReturnsEmpty(t *testing.T) {
+	emptyExtractor := func(_ context.Context) map[string]string { return nil }
+
+	inner := &capturingHttpClient{}
+	client := NewContextHeaderHttpClient(context.Background(), inner, emptyExtractor)
+
+	_ = client.Get(nil, "http://example.com")
+
+	// No headers should have been injected.
+	assert.Empty(t, inner.lastOpts.GetHeaders())
+}
+
+func TestContextHeaderHttpClient_MultipleExtractorsMerged(t *testing.T) {
+	extA := func(_ context.Context) map[string]string {
+		return map[string]string{"X-Compass-Trace-Id": "trace-123"}
+	}
+	extB := func(_ context.Context) map[string]string {
+		return map[string]string{"X-Compass-Service-Id": "svc-abc"}
+	}
+
+	inner := &capturingHttpClient{}
+	client := NewContextHeaderHttpClient(context.Background(), inner, extA, extB)
+
+	_ = client.Get(nil, "http://example.com")
+
+	headers := inner.lastOpts.GetHeaders()
+	assert.Equal(t, "trace-123", headers.Get("X-Compass-Trace-Id"))
+	assert.Equal(t, "svc-abc", headers.Get("X-Compass-Service-Id"))
+}
+
+func TestContextHeaderHttpClient_CallerOptOverridesExtractedHeader(t *testing.T) {
+	// The extractor supplies a trace ID, but the caller passes its own value
+	// for the same header. The caller's value should win because caller opts
+	// are appended after the extracted opts (prepend puts extracted opts first).
+	extractor := func(_ context.Context) map[string]string {
+		return map[string]string{"X-Compass-Trace-Id": "extracted-value"}
+	}
+
+	inner := &capturingHttpClient{}
+	client := NewContextHeaderHttpClient(context.Background(), inner, extractor)
+
+	_ = client.Get(nil, "http://example.com", WithHeader("X-Compass-Trace-Id", "caller-value"))
+
+	// withHeaders merges and the last write wins; caller opts come after extracted
+	// opts so the caller's value takes precedence.
+	assert.Equal(t, "caller-value", inner.lastOpts.GetHeaders().Get("X-Compass-Trace-Id"))
+}
+
+func TestContextHeaderHttpClient_ContextPassedToExtractor(t *testing.T) {
+	type ctxKey struct{}
+	ctx := context.WithValue(context.Background(), ctxKey{}, "my-service")
+
+	var capturedCtx context.Context
+	extractor := func(c context.Context) map[string]string {
+		capturedCtx = c
+		return nil
+	}
+
+	inner := &capturingHttpClient{}
+	client := NewContextHeaderHttpClient(ctx, inner, extractor)
+	_ = client.Get(nil, "http://example.com")
+
+	assert.Equal(t, "my-service", capturedCtx.Value(ctxKey{}))
+}
+
+func TestContextHeaderHttpClient_NoExtractors(t *testing.T) {
+	inner := &capturingHttpClient{}
+	client := NewContextHeaderHttpClient(context.Background(), inner)
+
+	_ = client.Get(nil, "http://example.com")
+
+	assert.Empty(t, inner.lastOpts.GetHeaders())
+}
+
+func TestContextHeaderHttpClient_SetRequesterDelegates(t *testing.T) {
+	inner := &capturingHttpClient{}
+	client := NewContextHeaderHttpClient(context.Background(), inner, traceExtractor("t"))
+
+	// Should not panic — SetRequester is delegated to the inner client.
+	client.SetRequester(nil)
+}
+
+func TestContextHeaderHttpClient_ComposedWithTracingDecorator(t *testing.T) {
+	// Verify the decorator can be stacked inside TracingHttpClientDecorator,
+	// which is the expected usage in production client factories.
+	const traceID = "crafting-composed-trace"
+
+	inner := &capturingHttpClient{}
+	withHeaders := NewContextHeaderHttpClient(context.Background(), inner, traceExtractor(traceID))
+
+	mt := newMockTracer()
+	composed := NewTracingHttpClientDecorator(
+		context.Background(),
+		withHeaders,
+		mt,
+		TracingHttpClientConfig{OperationName: "test.op", ServiceName: "test_svc"},
+	)
+
+	_ = composed.Get(nil, "http://example.com")
+
+	// Tracing decorator created a span.
+	assert.Len(t, mt.spans, 1)
+	// Header was propagated through to the inner client.
+	assert.Equal(t, traceID, inner.lastOpts.GetHeaders().Get("X-Compass-Trace-Id"))
+}


### PR DESCRIPTION
Adds NewContextHeaderHttpClient, a composable HttpClient decorator that injects headers derived from a context.Context into every outbound SDK request. One or more HeaderExtractor functions are provided at construction time; each receives the captured context and returns a map[string]string of headers to inject.

Design notes:

Follows the same context-capturing decorator pattern as TracingHttpClientDecorator — construct fresh per request-context scope.
Extracted headers are prepended to the opts slice so that explicit per-call WithHeader options and the Authorization header appended by ClientImpl.request always take precedence.
Multiple extractors are supported; results are merged before the request is made, with later extractors winning on collision.
Composable: intended to sit inside TracingHttpClientDecorator so tracing spans cover the full outbound call including injected headers.